### PR TITLE
Fix for Issue #791

### DIFF
--- a/lib/settings-common.php
+++ b/lib/settings-common.php
@@ -164,7 +164,7 @@ define('SALT_LENGTH',12);
 // Generate hash
 function generateHash($pw) {
     // Generate Bcrypt hash
-    return str_replace("\$", "\\$", password_hash($pw, PASSWORD_BCRYPT, $options = ['cost' => 10]));
+    return password_hash($pw, PASSWORD_BCRYPT, $options = ['cost' => 10]);
 }
 
 // Verify hash


### PR DESCRIPTION
When you hit the "Update" button in the settings menu for any reason, no matter
if you change anything or not, the password field in this file is updated and the
slashes"" are stripped and PHP can't properly read the hashed password without
the dollar signs escaped.